### PR TITLE
Removed 'Preview' from the MCP Extension section README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ languages:
 
 This document contains quickstart templates and additional resources to easily build and deploy a custom remote MCP server to the cloud using Azure functions. You can clone/restore/run on your local machine with debugging, and `azd up` to have it in the cloud in a couple minutes.  The MCP server is secured by design using keys and HTTPs, and allows more options for OAuth using EasyAuth and/or API Management as well as network isolation using VNET. 
 
-## Use the MCP Extension for Azure Functions [Preview]
+## Use the MCP Extension for Azure Functions
 
 You get a native Azure Functions experience turning code into MCP servers using the MCPTrigger.
 


### PR DESCRIPTION
Removed 'Preview' from the MCP Extension section.

## Purpose
This pull request makes a minor update to the `README.md` file by removing the "[Preview]" label from the section title about the MCP Extension for Azure Functions. This clarifies that the extension is no longer in preview status.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->